### PR TITLE
flash of "work" section on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,10 @@
             </div>
         </div>
     </section>
+    <script>
+        let winHeight = window.innerHeight;
+        document.getElementById("hero").style.height = winHeight + "px";
+    </script>
     <section aria-label="My Work" id="work" class="bg-primary">
         <div class="content-wrap">
             <h1 class="text-white">Work</h1>


### PR DESCRIPTION
Height of the hero section needs to be set with JS for hero lasers to work cross browser/device.

But the JS for setting the height was being placed at the end of the body in a script.

Added the JS to set the height in another script just after the hero loads to prevent the flash of the work section.